### PR TITLE
fix send data query result vector

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -346,10 +346,16 @@ impl<T: DeserializeOwned + Clone> ApiCall<Vec<T>> for DataQuery {
                     .from_reader(Cursor::new(csv_data))
             };
 
-            match reader.deserialize().next().unwrap() {
-                Ok(data) => data,
-                Err(e) => return Err(Error::ParsingFailed(e.to_string())),
+            let mut vec: Vec<T> = Vec::new();
+
+            for r in reader.deserialize() {
+                match r {
+                    Ok(data) => vec.push(data),
+                    Err(e) => return Err(Error::ParsingFailed(e.to_string())),
+                }
             }
+
+            vec
         };
 
         Ok(data)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -145,6 +145,28 @@ fn data_query() {
 }
 
 #[test]
+fn data_query_len() {
+    let query = {
+        let mut query = DataQuery::new("WIKI", "AAPL");
+
+        query.order(Order::asc)
+             .end_date(2016,2,5)
+             .start_date(2016,2,1)
+             .column_index(4);
+
+        if let Some(key) = API_KEY {
+            query.api_key(key);
+        }
+
+        query
+    };
+
+    let response: Vec<(String, f64)> = query.send().unwrap();
+
+    assert!(response.len() == 5);
+}
+
+#[test]
 fn batch_querying() {
     let query_1 = {
         let mut query = DatabaseMetadataQuery::new("WIKI");


### PR DESCRIPTION
i am new to rust. i tried the example code from the quandl github home page that attempts to get all the feb 2016 aapl prices but it only returned a vector of length 1. i added a test and made a fix. i'm not experienced with this so if i am missing anything please let me know. thanks.